### PR TITLE
Fix crash when using the 'set' command on Windows

### DIFF
--- a/mpsyt
+++ b/mpsyt
@@ -339,7 +339,7 @@ def has_known_player():
         match = re.search(regex, Config.PLAYER)
 
         if mswin:
-            match = re.search(regex, Config.Player, re.IGNORECASE)
+            match = re.search(regex, Config.PLAYER, re.IGNORECASE)
 
         if match:
             return True


### PR DESCRIPTION
when typing the `set` command on Windows, mpsyt crashes with the following error:

```

                88888b.d88b.  88888b.  .d8888b
                888 "888 "88b 888 "88b 88K
                888  888  888 888  888 "Y8888b.
                888  888  888 888 d88P      X88
                888  888  888 88888P"   88888P'
                              888
                              888   v0.01.31 (YouTube)
                              888



Enter /search-term to search or [h]elp
> set

Traceback (most recent call last):
  File "./mpsyt", line 2069, in <module>
    main()
  File "./mpsyt", line 2047, in main
    globals()[func](*matches)
  File "./mpsyt", line 382, in showconfig
    if not has_known_player() and setting == "FULLSCREEN":
  File "./mpsyt", line 342, in has_known_player
    match = re.search(regex, Config.Player, re.IGNORECASE)
AttributeError: type object 'Config' has no attribute 'Player'
```

This bug affects only the Windows plateform
