### PR TITLE
Add the overwrite true|false option.

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -597,6 +597,7 @@ class Config(object):
     SHOW_STATUS = ConfigItem("show_status", True)
     COLUMNS = ConfigItem("columns", "")
     DDIR = ConfigItem("ddir", get_default_ddir(), check_fn=check_ddir)
+    OVERWRITE = ConfigItem("overwrite", True)
     SHOW_VIDEO = ConfigItem("show_video", False)
     SEARCH_MUSIC = ConfigItem("search_music", True)
     WINDOW_POS = ConfigItem("window_pos", "", check_fn=check_win_pos)
@@ -2230,6 +2231,12 @@ def _download(song, filename, url=None, audio=False):
     # too many local variables
     # Instance of 'bool' has no 'url' member (some types not inferable)
 
+    if not Config.OVERWRITE.get:
+        if os.path.exists(filename):
+            print("File exists. Skipping %s%s%s ..\n" % (c.r, filename, c.w))
+            time.sleep(0.2)
+            return filename
+
     print("Downloading to %s%s%s ..\n" % (c.r, filename, c.w))
     status_string = ('  {0}{1:,}{2} Bytes [{0}{3:.2%}{2}] received. Rate: '
                      '[{0}{4:4.0f} kbps{2}].  ETA: [{0}{5:.0f} secs{2}]')
@@ -2727,7 +2734,7 @@ def show_help(choice):
                         " settings default reset configure audio results "
                         "max_results size lines rows height window "
                         "position window_pos quality resolution max_res "
-                        "columns width console".split()),
+                        "columns width console overwrite".split()),
 
              "playlists": ("save rename delete move rm ls mv sw add vp open"
                            " view".split())
@@ -2977,6 +2984,7 @@ def download(dltype, num):
         args = (song, filename)
         kwargs = dict(url=None, audio=audio)
 
+    print(os.path.exists(filename))
     try:
         # perform download(s)
         dl_filenames = [args[1]]
@@ -3854,6 +3862,7 @@ If you need to enter an actual comma on the command line, use {2},,{1} instead.
 {2}set columns <columns>{1} - select extra displayed fields in search results:
      (valid: views comments rating date user likes dislikes category)
 {2}set ddir <download direcory>{1} - set where downloads are saved
+{2}set overwrite true|false{1} - overwrite existing files (skip if false)
 {2}set fullscreen true|false{1} - output video content in full-screen mode
 {2}set max_res <number>{1} - play / download maximum video resolution height
 {2}set max_results <number>{1} - show <number> results when searching (max 50)


### PR DESCRIPTION
This option, if set to true, will overwrite existing downloaded files
but if set to false, will skip downloads for which there are existing
files in the current download directory. This allows for quickly
downloading new files in a playlist while ignoring the ones that are
already downloaded.
