### PR TITLE
New configuration option: notifier

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -47,7 +47,6 @@ import json
 import sys
 import re
 import os
-import string
 
 
 try:


### PR DESCRIPTION
The notifier, if one is set, is called whenever a song starts to play. The song title is passed as a parameter to the notifier. This can be used for system-wide song notifications.

For example, on Linux systems with [libnotify](https://wiki.archlinux.org/index.php/Desktop_notifications) installed, setting `notifier` to `notify-send` will create a desktop notification for each new song title.
