### PR TITLE
New configuration option: notifier [fixed]

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1705,6 +1705,7 @@ def launch_player(song, songdata, cmd):
     """ Launch player application. """
 
     try:
+        launch_notifier(song)
 
         if "mplayer" in Config.PLAYER.get:
             # fix for github issue 59
@@ -1718,13 +1719,6 @@ def launch_player(song, songdata, cmd):
         else:
             with open(os.devnull, "w") as devnull:
                 subprocess.call(cmd, stderr=devnull)
-
-        notifier = Config.NOTIFIER.get
-        if not notifier == '':
-            notifierCmd = notifier + " '" + song.title + "'"
-            with open(os.devnull, "w") as devnull:
-                subprocess.call(notifierCmd, stderr=devnull)
-
     except OSError:
         g.message = F('no player') % Config.PLAYER.get
         return
@@ -1736,6 +1730,17 @@ def launch_player(song, songdata, cmd):
         except (OSError, AttributeError, UnboundLocalError):
             pass
 
+def launch_notifier(song):
+    """ Launch notifier application. """
+
+    try:
+        notifier = Config.NOTIFIER.get
+        if not notifier == '':
+            notifierCmd = notifier + " '" + song.title + "'"
+            with open(os.devnull, "w") as devnull:
+                subprocess.call(notifierCmd, shell=True, stderr=devnull)
+    except OSError:
+        return
 
 def mplayer_status(popen_object, prefix="", songlength=0):
     """ Capture time progress from player output. Write status line. """


### PR DESCRIPTION
The notifier, if one is set, is called whenever a song starts to play. The song title is passed as a parameter to the notifier. This can be used for system-wide song notifications.

For example, on Linux systems with [libnotify](https://wiki.archlinux.org/index.php/Desktop_notifications) installed, setting `notifier` to `notify-send` will create a desktop notification for each new song title.

This change now works regardless of the player that is set and will work correctly with Unicode (I'm now using `subprocess.call` instead of `os.system`. Also, notifiers are documented under the Configuration documentation.
