### PR TITLE
Allow setting ddir using ~/path/

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -554,6 +554,7 @@ def check_console_width(val):
 
 def check_ddir(d):
     """ Check whether dir is a valid directory. """
+    d = os.path.expanduser(d)
     if os.path.isdir(d):
         message = "Downloads will be saved to " + c.y + d + c.w
         return dict(valid=True, message=message)


### PR DESCRIPTION
A minor fix to allow `set ddir ~/music`, instead of `set ddir /home/<user>/music`. 
