### PR TITLE
Update Dockerfile and build dockerfile automatically using github actions

### DIFF
--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the Docker image
       run: |
-        docker login --user tommysolsen -p $PASSWORD 
+        docker login --username tommysolsen -p $PASSWORD 
         docker build . --file Dockerfile --tag mpsyt/mps_youtube:develop
         docker push mpsyt/mps_youtube:develop
       env:

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Build Image from develop
 
 on: 
   push:
@@ -15,5 +15,6 @@ jobs:
       run: |
         docker login --user tommysolsen -p $PASSWORD 
         docker build . --file Dockerfile --tag mpsyt/mps_youtube:develop
+        docker push mpsyt/mps_youtube:develop
       env:
         PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -1,0 +1,19 @@
+name: Docker Image CI
+
+on: 
+  push:
+    branches: 
+      - develop
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: |
+        docker login --user tommysolsen -p $PASSWORD 
+        docker build . --file Dockerfile --tag mpsyt/mps_youtube:develop
+      env:
+        PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the Docker image
       run: |
-        docker login --username tommysolsen -p $PASSWORD 
+        docker login --username $USERNAME -p $PASSWORD 
         docker build . --file Dockerfile --tag mpsyt/mps_youtube:develop
         docker push mpsyt/mps_youtube:develop
       env:

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the Docker image
       run: |
-        docker login --username tommysolsen -p $PASSWORD 
+        docker login --username $USERNAME -p $PASSWORD 
         docker build . --file Dockerfile --tag mpsyt/mps_youtube:latest
         docker tag mpsyt/mps_youtube:latest mpsyt/mps_youtube:master
         docker push mpsyt/mps_youtube:latest

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -1,0 +1,21 @@
+name: Build latest image
+
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: |
+        docker login --username tommysolsen -p $PASSWORD 
+        docker build . --file Dockerfile --tag mpsyt/mps_youtube:latest
+        docker tag mpsyt/mps_youtube:latest mpsyt/mps_youtube:master
+        docker push mpsyt/mps_youtube:latest
+        docker push mpsyt/mps_youtube:master
+      env:
+        PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3-stretch
+ARG PYTHON_IMAGE=3
+FROM python:${PYTHON_IMAGE}
 
 LABEL maintainer="Justin Garrison <justinleegarrison@gmail.com>" \
     org.label-schema.schema-version="1.0" \
@@ -14,6 +15,12 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean && apt-get purge
 
-RUN pip install mps-youtube youtube-dl
+RUN pip install pafy youtube-dl
+
+COPY mpsyt /usr/local/bin
+COPY mps_youtube /tmp/mps_youtube
+
+RUN mkdir -p $(python -m site --user-site)
+RUN mv /tmp/mps_youtube $(python -m site --user-site)/mps_youtube
 
 ENTRYPOINT ["mpsyt"]

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ Run via Docker container
 
 Using `Docker <http://www.docker.com>`_, run with::
 
-    sudo docker run --device /dev/snd -it --rm --name mpsyt rothgar/mpsyt
+    sudo docker run --device /dev/snd -it --rm --name mpsyt mpsyt/mps_youtube
 
 Additional Docker notes
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Before merging this PR we need to set up some tokens for Github Actions to be able to push to dockerhub**

# Dockerfile changes
We now build the Docker image from the source code in the repository instead of downloading the newest version of pip. This way we can release multiple images of different (and unreleased versions) through dockerhub.

# New mpsyt organization on dockerhub.
I've created a new organization for mpsyt on dockerhub. I'll have to somehow get in touch with contributors in the mpsyt org in order to add them to the org and sort out owner rights at some point.

# Github actions
This PR also adds a few simple workflows that lets us automatically build images when we update the master and develop branch of the repository. The images are pushed to the aforementioned newly created org.

In order to facilitate that, we need to set a dockerhub secret to grant push rights. However it looks like only @ids1024 has access to do that. I can add him as owner to the dockerhub org, then he can create a security token and add that to the repo secrets and then we can automatically perform changes here.

We could/should also set up some schedule based workflows which would check and rebuild the images if youtube-dl has been updated. As well as building tagged versions of the software as well.