### PR TITLE
Added KeyError exception handle for mpv _player_status

### DIFF
--- a/mps_youtube/mpris.py
+++ b/mps_youtube/mpris.py
@@ -223,8 +223,11 @@ class Mpris2MediaPlayer(dbus.service.Object):
                     self._sendcommand(["observe_property", 4, "seeking"])
                     observe_full = True
 
-                if resp.get('event') == 'property-change':
-                    self.setproperty(resp['name'], resp['data'])
+                try:
+                    if resp.get('event') == 'property-change':
+                        self.setproperty(resp['name'], resp['data'])
+                except KeyError:
+                    continue
 
         except socket.error:
             self.socket = None

--- a/mps_youtube/players/mpv.py
+++ b/mps_youtube/players/mpv.py
@@ -184,8 +184,11 @@ class mpv(CmdPlayer):
                         observe_full = True
 
                     if resp.get('event') == 'property-change' and resp['id'] == 1:
-                        if resp['data'] is not None:
-                            elapsed_s = int(resp['data'])
+                        try:
+                            if resp['data'] is not None:
+                                elapsed_s = int(resp['data'])
+                        except KeyError:
+                            elapsed_s = int(-1)
 
                     elif resp.get('event') == 'property-change' and resp['id'] == 2:
                         volume_level = int(resp['data'])


### PR DESCRIPTION
Sometimes mpv will crash at random if it can't cant get the elapsed time (for whatever reason). Attached error I kept getting from this issue 
![error](https://user-images.githubusercontent.com/15500467/83219749-a8d9cd80-a160-11ea-8b5c-a6672dc83da6.png)
