### PR TITLE
Fix mix command

### DIFF
--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -21,7 +21,7 @@ parser.add_argument('search', nargs='+')
 from .. import c, config, content, contentquery, g, listview, screen, util
 from ..playlist import Playlist, Video
 from . import command
-from .songlist import paginatesongs, plist
+from .songlist import paginatesongs, plist, mixlist
 
 ISO8601_TIMEDUR_EX = re.compile(r'PT((\d{1,3})H)?((\d{1,3})M)?((\d{1,2})S)?')
 
@@ -523,11 +523,10 @@ def mix(num):
         if item is None:
             g.message = util.F('invalid item')
             return
-        item = util.get_pafy(item)
-        # Mix playlists are made up of 'RD' + video_id
+        item = g.model[int(num) -1]
         try:
-            plist("RD" + item.videoid)
-        except OSError:
+            mixlist(item.ytid)
+        except KeyError:
             g.message = util.F('no mix')
 
 

--- a/mps_youtube/commands/songlist.py
+++ b/mps_youtube/commands/songlist.py
@@ -94,6 +94,21 @@ def plist(parturl):
     loadmsg = "Retrieving YouTube playlist"
     paginatesongs(pl_seg, length=len(ytpl.videos), msg=msg, loadmsg=loadmsg)
 
+def mixlist(video_url):
+    """ Retrieve YouTube mix from video slug """
+
+    util.dbg("%sFetching mix using pafy%s", c.y, c.w)
+    # No caching here because mixes are different every time they are retrieved
+    ytpl = pafy.get_mix(video_url)
+    plitems = util.IterSlicer(ytpl.songs)
+
+    def pl_seg(s, e):
+        return [Video(i["id"], i["title"], i["duration_parsed"]) for i in plitems[s:e]]
+
+    msg = "Showing YouTube playlist %s" % (c.y + ytpl.name + c.w)
+    loadmsg = "Retrieving YouTube playlist"
+    paginatesongs(pl_seg, length=len(ytpl.songs), msg=msg, loadmsg=loadmsg)
+
 
 @command(r'(rm|add)\s*(-?\d[-,\d\s]{,250})', 'rm', 'add')
 def songlist_rm_add(action, songrange):


### PR DESCRIPTION
YouTube updates mean that `youtube-search-python` can no longer fetch mixes properly; they behave slightly differently to playlists.

The solution is to split these functions out and fetch the data using `yt-dlp`.