### PR TITLE
Update project URL and version maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Installation
 # Latest Version
 
 ### Using pip
-1. Install using `pip install git+https://github.com/iamtalhaasghar/yewtube.git`
+1. Install using `pip install git+https://github.com/mps-youtube/yewtube.git`
 2. Run using, `yt`. Enjoy! 
 
 ### Using pipx
 1.  Install **_pipx_** using `pip install pipx`
-2.  Install `yewtube` using `pipx install git+https://github.com/iamtalhaasghar/yewtube.git`
+2.  Install `yewtube` using `pipx install git+https://github.com/mps-youtube/yewtube.git`
 3.  Now, type `yt` That's it.
 
 What's new in yewtube?
@@ -46,7 +46,7 @@ What's new in yewtube?
 -   **No Youtube API Key required**
 -   **Run audio in VLC with no GUI**
 
-See complete and up-to-date changelog [here](https://github.com/iamtalhaasghar/yewtube/blob/master/CHANGELOG.md).
+See complete and up-to-date changelog [here](https://github.com/mps-youtube/yewtube/blob/master/CHANGELOG.md).
 
 These features are still inherited from [mps-youtube](https://github.com/mps-youtube/mps-youtube).
 -   Search and play audio/video from YouTube
@@ -65,7 +65,7 @@ implementation uses YouTube as a source of content and can play and
 download video as well as audio. The [pafy](https://github.com/mps-youtube/pafy)  library handles interfacing with YouTube.
 
 [mps-youtube wiki](https://github.com/mps-youtube/mps-youtube/wiki/Troubleshooting) <br>
-[yewtube wiki](https://github.com/iamtalhaasghar/yewtube/wiki/FAQ)
+[yewtube wiki](https://github.com/mps-youtube/yewtube/wiki/FAQ)
 
 Screenshots
 -----------
@@ -202,9 +202,9 @@ If everything working correctly, dbug and glib would have similar result as abov
 mps-youtube.instance567867
 ```
 
-Check also the [common-issue](https://github.com/iamtalhaasghar/yewtube/wiki/Common-issues) if you are having problem with yewtube.
+Check also the [common-issue](https://github.com/mps-youtube/yewtube/wiki/Common-issues) if you are having problem with yewtube.
 
 How to Contribute
 -----------------
 
-Contributions are warmly welcomed! However, please check out the [contribution page](https://github.com/iamtalhaasghar/yewtube/blob/master/CONTRIBUTING.md) before making a contribution.
+Contributions are warmly welcomed! However, please check out the [contribution page](https://github.com/mps-youtube/yewtube/blob/master/CONTRIBUTING.md) before making a contribution.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Yewtube
 site_description: Terminal based YouTube player and downloader.
 site_url: https://iamtalhaasghar.github.io/yewtube
-repo_url: https://github.com/iamtalhaasghar/yewtube
-repo_name: iamtalhaasghar/yewtube
+repo_url: https://github.com/mps-youtube/yewtube
+repo_name: mps-youtube/yewtube
 
 nav:
 - Home:

--- a/mps_youtube/__init__.py
+++ b/mps_youtube/__init__.py
@@ -3,5 +3,5 @@ from pip._vendor import pkg_resources
 __version__ = next((p.version for p in pkg_resources.working_set if p.project_name.lower() == 'yewtube'), "unable to determine")
 __author__ = "iamtalhaasghar"
 __license__ = "GPLv3"
-__url__ = "https://github.com/iamtalhaasghar/yewtube"
+__url__ = "https://github.com/mps-youtube/yewtube"
 

--- a/mps_youtube/commands/misc.py
+++ b/mps_youtube/commands/misc.py
@@ -60,7 +60,7 @@ def quits(showlogo=True):
     if config.CHECKUPDATE.get and showlogo:
 
         try:
-            url = "https://raw.githubusercontent.com/iamtalhaasghar/yewtube/master/setup.py"
+            url = "https://raw.githubusercontent.com/mps-youtube/yewtube/master/setup.py"
             v = urlopen(url, timeout=1).read().decode()
             v = re.search(r'__version__\s*=\s*"\s*([\d\.]+)\s*"\s*', v, re.MULTILINE)
 

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -96,7 +96,7 @@ argument_commands = []
 commands = []
 
 text = {
-    "exitmsg": ("*yewtube - https://github.com/iamtalhaasghar/yewtube is a fork of\nmps-youtube - *https://github.com/mps-youtube/mps-youtube*"
+    "exitmsg": ("*yewtube - https://github.com/mps-youtube/yewtube is a fork of\nmps-youtube - *https://github.com/mps-youtube/mps-youtube*"
                 "\nReleased under the GPLv3 license\n"
                 "(c) 2021 iamtalhaasghar\n(c) 2014, 2015 np1 and contributors*\n"""),
     "exitmsg_": (c.r, c.b, c.r, c.w),

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -408,7 +408,7 @@ def get_help(choice):
 
 def get_changelog():
     try:
-        url = "https://raw.githubusercontent.com/iamtalhaasghar/yewtube/master/CHANGELOG.md"
+        url = "https://raw.githubusercontent.com/mps-youtube/yewtube/master/CHANGELOG.md"
         v = urlopen(url, timeout=1).read().decode()
         v = v.split('## v')[1]
         return v

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -315,7 +315,7 @@ def helptext():
         ),
         (
             "new",
-            "Check if new version is available",
+            "Show online changelog for the latest version",
             """{0}What's New{1}\n{3}""".format(c.ul, c.w, c.y, "get_changelog()"),
         ),
         (

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 with open('requirements.txt', 'r') as fh:
     requirements = fh.readlines()
 
-__version__ = "2.10.4"
+__version__ = "2.10.5"
 
 options = dict(
     name="yewtube",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 """ setup.py for yewtube.
 
-https://github.com/iamtalhaasghar/yewtube
+https://github.com/mps-youtube/yewtube
 
 python setup.py sdist bdist_wheel
 """
@@ -30,8 +30,8 @@ options = dict(
     keywords=["video", "music", "audio", "youtube", "stream", "download"],
     author="talha_programmer",
     author_email="talhaasghar.contact@simplelogin.fr",
-    url="https://github.com/iamtalhaasghar/yewtube",
-    download_url="https://github.com/iamtalhaasghar/yewtube/releases",
+    url="https://github.com/mps-youtube/yewtube",
+    download_url="https://github.com/mps-youtube/yewtube/releases",
     packages=['mps_youtube', 'mps_youtube.commands', 'mps_youtube.listview', 'mps_youtube.players'],
     entry_points={'console_scripts': ['yt = mps_youtube:main.main']},
     python_requires='>=3.6',


### PR DESCRIPTION
Update the project URL across the codebase to reflect the move to `mps-youtube/yewtube`. This also fixes the changelog showing the wrong version. Also update the helptext for `help new` to make it clearer what it does.

I also bumped the version in `setup.py` to reflect the latest release to stop update notifications.