### PR TITLE
fix syntax warnings on 3.12

### DIFF
--- a/mps_youtube/util.py
+++ b/mps_youtube/util.py
@@ -492,7 +492,7 @@ def _get_mpv_version(exename):
 
 def _get_mplayer_version(exename):
     o = subprocess.check_output([exename]).decode()
-    m = re.search('MPlayer SVN[\s-]r([0-9]+)', o, re.MULTILINE|re.IGNORECASE)
+    m = re.search(r'MPlayer SVN[\s-]r([0-9]+)', o, re.MULTILINE|re.IGNORECASE)
 
     ver = 0
     if m:
@@ -510,7 +510,7 @@ def _get_mplayer_version(exename):
 
 def _get_metadata(song_title):
     ''' Get metadata from a song title '''
-    t = re.sub("[\(\[].*?[\)\]]", "", song_title.lower())
+    t = re.sub(r"[\(\[].*?[\)\]]", "", song_title.lower())
     t = t.split('-')
 
     if len(t) != 2:  # If len is not 2, no way of properly knowing title for sure


### PR DESCRIPTION
Fixes #1256

These raise `SyntaxWarning`'s on python 3.12:

```console
$ yt
/opt/homebrew/Cellar/yewtube/2.10.5/libexec/lib/python3.12/site-packages/mps_youtube/util.py:495: SyntaxWarning: invalid escape sequence '\s'
  m = re.search('MPlayer SVN[\s-]r([0-9]+)', o, re.MULTILINE|re.IGNORECASE)
/opt/homebrew/Cellar/yewtube/2.10.5/libexec/lib/python3.12/site-packages/mps_youtube/util.py:513: SyntaxWarning: invalid escape sequence '\('
```
