### PR TITLE
Implemented option to pipe url directly to mpv

### DIFF
--- a/mps_youtube/config.py
+++ b/mps_youtube/config.py
@@ -343,6 +343,7 @@ class _Config:
             ConfigItem("pages", 3, minval=1, maxval=100),
             ConfigItem("autoplay", False),
             ConfigItem("set_title", True),
+            ConfigItem("pipe_direct_mpv", False),
             ConfigItem("mpris", not mswin),
             ConfigItem("show_qrcode", False),
             ConfigItem("history", True), 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -175,6 +175,3 @@ def main():
                 sys.exit("Bad syntax")
 
         screen.update()
-
-if __name__ == "__main__":
-	main()

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -175,3 +175,6 @@ def main():
                 sys.exit("Bad syntax")
 
         screen.update()
+
+if __name__ == "__main__":
+	main()

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -142,6 +142,7 @@ class BasePlayer:
             songdata = (self.song.ytid, '' if self.stream.get('ext') is None else self.stream.get('ext') + " " + self.stream['quality'],
                             int(size / (1024 ** 2)))
 
+        self.songdata = "%s; %s; %s Mb" % songdata
         screen.writestatus(self.songdata)
 
         self._launch_player()

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -132,10 +132,16 @@ class BasePlayer:
         if config.NOTIFIER.get:
             subprocess.Popen(shlex.split(config.NOTIFIER.get) + [self.song.title])
 
-        size = streams.get_size(self.song.ytid, self.stream['url'])
-        songdata = (self.song.ytid, '' if self.stream.get('ext') is None else self.stream.get('ext') + " " + self.stream['quality'],
-                    int(size / (1024 ** 2)))
-        self.songdata = "%s; %s; %s Mb" % songdata
+        #option does not interfere unless mpv is selected as the player.
+        if config.PIPE_DIRECT_MPV.get and config.PLAYER.get == 'mpv':
+            songdata = (self.song.ytid, 'Direct to MPV ',
+                            0)
+        else:
+            size = streams.get_size(self.song.ytid, self.stream['url'])
+
+            songdata = (self.song.ytid, '' if self.stream.get('ext') is None else self.stream.get('ext') + " " + self.stream['quality'],
+                            int(size / (1024 ** 2)))
+
         screen.writestatus(self.songdata)
 
         self._launch_player()
@@ -317,6 +323,19 @@ class CmdPlayer(BasePlayer):
 def stream_details(song, failcount=0, override=False, softrepeat=False):
     """Fetch stream details for a song."""
     # don't interrupt preloading:
+    if config.PIPE_DIRECT_MPV.get and config.PLAYER.get == 'mpv':
+        video = ((config.SHOW_VIDEO.get and override != "audio") or
+                 (override in ("fullscreen", "window", "forcevid")))
+        # doesn't matter - since we are passing direct to mpv we only care about the url
+        stream = {"url": str('https://www.youtube.com/watch?v=%s' % song.ytid),
+                "ext": 'mp4',
+                "quality": str(config.MAX_RES.get),
+                "rawbitrate": 99,
+                "mtype": 'video',
+                "size": 100} 
+
+        return (video, stream, override)
+
     while song.ytid in g.preloading:
         screen.writestatus("fetching item..")
         time.sleep(0.1)

--- a/mps_youtube/players/mpv.py
+++ b/mps_youtube/players/mpv.py
@@ -73,7 +73,7 @@ class mpv(CmdPlayer):
             util.dbg("%susing ignidx flag%s")
             util.list_update(pd["ignidx"], args)
 
-        if "--ytdl" in self.mpv_options:
+        if "--ytdl" in self.mpv_options and not config.PIPE_DIRECT_MPV.get:
             util.list_update("--no-ytdl", args)
 
         msglevel = pd["msglevel"]["<0.4"]


### PR DESCRIPTION
Hi!

Thanks for this project, it's been of great use on my ancient 2007 Macbook Pro - I can use mpv with --hwdec and --vo flags to get hardware accelerated video playback, which on a 17 year old CPU is a very welcome help.

However I was running into the 640x360 issue as in #942, so I decided to write this little patch to allow the URL to be piped directly to mpv and the --ytdl-format player args to be used to control the output instead (in my case limiting the resolution to 720p as the GPU runs out of VRAM)

Happy to make any changes needed (what default values would you suggest setting for the stream dict?)