### PR TITLE
Fix Issue #1064 and #1283: User and Channel searches to return all vi…

### DIFF
--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -216,7 +216,14 @@ Use 'set search_music False' to show results not in the Music category.""" % ter
         else:
             failmsg = "User %s not found or has no videos."  % termuser[1]
     msg = str(msg).format(c.w, c.y, c.y, term, user)
-    results = pafy.all_videos_from_channel(channel_id)
+
+    videos = pafy.all_videos_from_channel(channel_id)
+    query = term.lower() if term else None
+
+    if query:
+        results = [v for v in videos if query in v.get('title', '').lower() or query in v.get('description', '').lower()]
+    else:
+        results = videos
     _display_search_results(progtext, results, msg, failmsg)
 
 

--- a/mps_youtube/pafy.py
+++ b/mps_youtube/pafy.py
@@ -119,7 +119,13 @@ def channel_id_from_name(query):
     return (channel_id, channel_name)
 
 def all_videos_from_channel(channel_id):
+    '''
+    Get all videos of a playlist identified by channel_id
+    '''
+
     playlist = Playlist(playlist_from_channel_id(channel_id))
+    while playlist.hasMoreVideos:
+        playlist.getNextVideos()
     return playlist.videos
 
 def search_videos_from_channel(channel_id, query):


### PR DESCRIPTION
…deos including optional filtering of search terms (#1282)

* Updated the all_videos_from_channel function to return all videos from a channel, not just the first page of playlist results (previous method only returned up to 100 videos max).

* Updated the usersearch_id function to filter the returned videos by search term in the title or description. This restores the ability to search a user's videos.