### PR TITLE
Demonstrate using existing mpv bindings with yewtube

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ yewtube is run on the command line using the command:
 Enter `h` from within the program for help.
 
 
+Using yewtube with mpv
+----------------------
+
+If you have `mpv` player installed and you set it to be used as the player
+you can have yewtube to use its input bindings (with only a few usability changes
+done automatically by yewtube) by soft-linking to it from `~/.config/mps-youtube/mpv-input.conf`
+like so:
+
+```shell
+> ln -sr ~/.config/mpv/input.conf ~/.config/mps-youtube/mpv-input.conf
+```
+
 Using yewtube with mpris
 ------------------------
 


### PR DESCRIPTION
The soft-linked `input.conf` file will be used with some slight adaptions  [that are shown here](https://github.com/mps-youtube/yewtube/blob/master/mps_youtube/players/mpv.py#L296-L309) 

Added an explanation & example to README of how to create the link.
This can prove useful to newbies or people who don't care to look how the software works to find out.