### PR TITLE
Add support for high-res video.

### DIFF
--- a/mps_youtube/players/mplayer.py
+++ b/mps_youtube/players/mplayer.py
@@ -70,6 +70,11 @@ class mplayer(CmdPlayer):
         util.list_update("-cache", args)
         util.list_update("4096", args)
 
+        # MPlayer currently only supports audio files local to the filesystem,
+        # so this will not work with audio streams.
+        if 'audio_url' in self.stream and self.stream['mtype'] == 'video_only':
+            util.list_update(f'-audiofile {self.stream["audio_url"]}', args)
+
         return [self.player] + args + [self.stream['url']]
 
     def clean_up(self):

--- a/mps_youtube/players/mpv.py
+++ b/mps_youtube/players/mpv.py
@@ -98,6 +98,9 @@ class mpv(CmdPlayer):
             util.list_update('--no-video', args)
             util.list_update('--vid=no', args)
 
+        if 'audio_url' in self.stream and self.stream['mtype'] == 'video_only':
+            util.list_update(f'--audio-file={self.stream["audio_url"]}', args)
+
         return [self.player] + args + [self.stream['url']]
 
     def clean_up(self):

--- a/mps_youtube/players/vlc.py
+++ b/mps_youtube/players/vlc.py
@@ -24,6 +24,9 @@ class vlc(CmdPlayer):
         if self.subtitle_path:
             args.extend(('--sub-file', self.subtitle_path))
 
+        if 'audio_url' in self.stream and self.stream['mtype'] == 'video_only':
+            util.list_update(f'--input-slave={self.stream["audio_url"]}', args)
+
         util.list_update("--play-and-exit", args)
 
         return [self.player] + args + [self.stream['url']]


### PR DESCRIPTION
### Summary
This PR adds support for playing high-res video (with audio) via the `vlc` and `mpv` players.  

### Details
YT started splitting high-res video and audio into separate streams some time ago.  The only stream that typically combines the two is the low-res 360p phone-compatible stream.  

This PR addresses [issue #942](https://github.com/mps-youtube/yewtube/issues/942), by leveraging the ability for `mpv` and `vlc` to accept separate audio and video streams as CLI parameters.  (See separate note below for `mplayer`.)

This PR is a more general solution than [thatonearchguy](https://github.com/thatonearchguy)'s #1284 PR, leveraging the current URL handling architecture.  

### Compatibility Note
While `mplayer` does provide support for loading and playing a separate audio file, `mplayer` will only load local files and does not support streaming from remote URLs.  Due to this limitation, this PR leaves the default functionality untouched for `mplayer` (meaning it will only play the 360p streams).  

### Code Formatting Note
I followed the PEP-8 standards for most of the code except where that would conflict with the existing code formatting (long lines).  I'm more than happy to adjust that (or anything else) based on feedback!  

### Testing
Testing was manual.  I've been running these changes for the past few months on Linux. 

These changes have also been tested on Windows and work for `vlc` and `mpv`.  

I also verified that the download feature continues to work, although it is unlikely this change would have affected it as it uses the built-in `yt-dlp` download functionality via `pafy`.  

### Known Issues
Having run this for a couple months, I've noticed two occasions where `mpv` would play the video, but not the audio stream.  This seems to have been due to a network failure when `mpv` attempted to retrieve the audio stream.  Stopping the stream and restarting it fixed the problem in both cases.  