### PR TITLE
Fix cases of config values not being checked properly

### DIFF
--- a/mps_youtube/commands/search.py
+++ b/mps_youtube/commands/search.py
@@ -210,7 +210,7 @@ def usersearch_id(user, channel_id, term):
     else:
         msg = "Video uploads by {2}{4}{0}"
         progtext = termuser[1]
-        if config.SEARCH_MUSIC:
+        if config.SEARCH_MUSIC.get:
             failmsg = """User %s not found or has no videos in the Music category.
 Use 'set search_music False' to show results not in the Music category.""" % termuser[1]
         else:

--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -71,7 +71,7 @@ class BasePlayer:
                 lastfm.set_now_playing(g.artist, g.scrobble_queue[self.song_no])
 
             try:
-                if config.SHOW_VIDEO and config.SHOW_SUBTITLES:
+                if config.SHOW_VIDEO.get and config.SHOW_SUBTITLES.get:
                     self.subtitle_path = pafy.get_subtitles(self.song.ytid, config.DDIR.get)
                 self.video, self.stream, self.override = stream_details(
                                                             self.song,


### PR DESCRIPTION
In a couple of cases, config values were incorrectly being checked using, for example, `config.SEARCH_MUSIC` instead of `config.SEARCH_MUSIC.get`. The former syntax will always return a truthy value assuming that the configuration item exists (which it should in all cases), whereas the latter actually checks the config value itself.