### PR TITLE
Add pyreadline3 backup import for readline

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -37,7 +37,7 @@ except ImportError:
         from pyreadline3 import Readline
         readline = Readline()
     except ImportError:
-        pass
+        has_readline = False
 if readline:
     readline.set_history_length(2000)
     has_readline = True


### PR DESCRIPTION
`readline` is unavailable on Windows. Without this fix, the following error occurs when attempting to launch yewtube:

```
  File "C:\Python313\Lib\site-packages\mps_youtube\commands\__init__.py", line 28, in command
    completer.add_cmd(command)
    ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'add_cmd'```