### PR TITLE
Fixed the config check of subtitles ignored

### DIFF
--- a/mps_youtube/player.py
+++ b/mps_youtube/player.py
@@ -44,6 +44,7 @@ class BasePlayer:
         self.shuffle = shuffle
         self.repeat = repeat
         self.override = override
+        self.subtitle_path = None
         if shuffle:
             random.shuffle(self.songlist)
 
@@ -71,7 +72,7 @@ class BasePlayer:
                 lastfm.set_now_playing(g.artist, g.scrobble_queue[self.song_no])
 
             try:
-                if config.SHOW_VIDEO and config.SHOW_SUBTITLES:
+                if config.SHOW_VIDEO.get and config.SHOW_SUBTITLES.get:
                     self.subtitle_path = pafy.get_subtitles(self.song.ytid, config.DDIR.get)
                 self.video, self.stream, self.override = stream_details(
                                                             self.song,

--- a/mps_youtube/players/vlc.py
+++ b/mps_youtube/players/vlc.py
@@ -21,7 +21,7 @@ class vlc(CmdPlayer):
         if not config.SHOW_VIDEO.get:
             args.extend(("--no-video",))
 
-        if self.subtitle_path:
+        if self.__getattribute__('subtitle_path'):
             args.extend(('--sub-file', self.subtitle_path))
 
         util.list_update("--play-and-exit", args)


### PR DESCRIPTION
The parameters SHOW_VIDEO and SHOW_SUBTITLES were ignored in the BasePlayer class. I needed to disable subtitle download because pafy returned a 429 error code (Too Many Requests)